### PR TITLE
Tidy markdown headings for compatibility with atom's markdown-preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Node.js Alexa Skills Kit Samples
 
-##Alexa Skills Kit Documentation
+## Alexa Skills Kit Documentation
 The documentation for the Alexa Skills Kit is available on the [Amazon Apps and Services Developer Portal](https://developer.amazon.com/appsandservices/solutions/alexa/alexa-skills-kit/).
 
 ## Contents

--- a/samples/helloWorld/README.md
+++ b/samples/helloWorld/README.md
@@ -1,4 +1,4 @@
-#Sample AWS Lambda function for Alexa
+# Sample AWS Lambda function for Alexa
 A simple [AWS Lambda](http://aws.amazon.com/lambda) function that demonstrates how to write a skill for the Amazon Echo using the Alexa SDK.
 
 ## Concepts

--- a/samples/historyBuff/README.md
+++ b/samples/historyBuff/README.md
@@ -1,4 +1,4 @@
-#Sample AWS Lambda function for Alexa
+# Sample AWS Lambda function for Alexa
 A simple [AWS Lambda](http://aws.amazon.com/lambda) function that demonstrates how to write a skill for the Amazon Echo using the Alexa SDK.
 
 ## Concepts

--- a/samples/historyBuff/README.md
+++ b/samples/historyBuff/README.md
@@ -46,7 +46,7 @@ Example user interactions:
 ### One-shot model:
     User:  "Alexa, ask History Buff what happened on August thirtieth."
     Alexa: "For August thirtieth, in 2003, [...] . Wanna go deeper in history?"
-    User: "No."
+    User:  "No."
     Alexa: "Good bye!"
 
 ### Dialog model:
@@ -56,6 +56,6 @@ Example user interactions:
     Alexa: "For August thirtieth, in 2003, [...] . Wanna go deeper in history?"
     User:  "Yes."
     Alexa: "In 1995, Bosnian war [...] . Wanna go deeper in history?"
-    User: "No."
+    User:  "No."
     Alexa: "Good bye!"
 

--- a/samples/historyBuff/README.md
+++ b/samples/historyBuff/README.md
@@ -44,18 +44,18 @@ To run this example skill you need to do two things. The first is to deploy the 
 Example user interactions:
 
 ### One-shot model:
-  User:  "Alexa, ask History Buff what happened on August thirtieth."
-  Alexa: "For August thirtieth, in 2003, [...] . Wanna go deeper in history?"
-  User: "No."
-  Alexa: "Good bye!"
+    User:  "Alexa, ask History Buff what happened on August thirtieth."
+    Alexa: "For August thirtieth, in 2003, [...] . Wanna go deeper in history?"
+    User: "No."
+    Alexa: "Good bye!"
 
 ### Dialog model:
-  User:  "Alexa, open History Buff"
-  Alexa: "History Buff. What day do you want events for?"
-  User:  "August thirtieth."
-  Alexa: "For August thirtieth, in 2003, [...] . Wanna go deeper in history?"
-  User:  "Yes."
-  Alexa: "In 1995, Bosnian war [...] . Wanna go deeper in history?"
-  User: "No."
-  Alexa: "Good bye!"
+    User:  "Alexa, open History Buff"
+    Alexa: "History Buff. What day do you want events for?"
+    User:  "August thirtieth."
+    Alexa: "For August thirtieth, in 2003, [...] . Wanna go deeper in history?"
+    User:  "Yes."
+    Alexa: "In 1995, Bosnian war [...] . Wanna go deeper in history?"
+    User: "No."
+    Alexa: "Good bye!"
 

--- a/samples/minecraftHelper/README.md
+++ b/samples/minecraftHelper/README.md
@@ -1,4 +1,4 @@
-#Sample AWS Lambda function for Alexa
+# Sample AWS Lambda function for Alexa
 A simple [AWS Lambda](http://aws.amazon.com/lambda) function that demonstrates how to write a skill for the Amazon Echo using the Alexa SDK.
 
 ## Concepts

--- a/samples/savvyConsumer/README.md
+++ b/samples/savvyConsumer/README.md
@@ -1,4 +1,4 @@
-#Sample AWS Lambda function for Alexa
+# Sample AWS Lambda function for Alexa
 A simple [AWS Lambda](http://aws.amazon.com/lambda) function that demonstrates how to write a skill for the Amazon Echo using the Alexa SDK.
 
 ## Concepts

--- a/samples/scoreKeeper/README.md
+++ b/samples/scoreKeeper/README.md
@@ -1,4 +1,4 @@
-#Sample AWS Lambda function for Alexa
+# Sample AWS Lambda function for Alexa
 A simple [AWS Lambda](http://aws.amazon.com/lambda) function that demonstrates how to write a skill for the Amazon Echo using the Alexa SDK.
 
 ## Concepts

--- a/samples/spaceGeek/README.md
+++ b/samples/spaceGeek/README.md
@@ -1,4 +1,4 @@
-#Sample AWS Lambda function for Alexa
+# Sample AWS Lambda function for Alexa
 A simple [AWS Lambda](http://aws.amazon.com/lambda) function that demonstrates how to write a skill for the Amazon Echo using the Alexa SDK.
 
 ## Concepts

--- a/samples/tidePooler/README.md
+++ b/samples/tidePooler/README.md
@@ -1,4 +1,4 @@
-#Sample AWS Lambda function for Alexa
+# Sample AWS Lambda function for Alexa
 A simple [AWS Lambda](http://aws.amazon.com/lambda) function that demonstrates how to write a skill for the Amazon Echo using the Alexa SDK.
 
 ## Concepts

--- a/samples/wiseGuy/README.md
+++ b/samples/wiseGuy/README.md
@@ -1,4 +1,4 @@
-#Sample AWS Lambda function for Alexa
+# Sample AWS Lambda function for Alexa
 A simple [AWS Lambda](http://aws.amazon.com/lambda) function that demonstrates how to write a skill for the Amazon Echo using the Alexa SDK.
 
 ## Concepts


### PR DESCRIPTION
- When viewing the `README.md` files in Atom's markdown-preview, I noticed that the headings sometimes weren't rendered properly. Upon investigation I discovered that simply adding a space to separate the leading hash marks from the heading resolved the rendering issue.

- This was originally part of a larger change in amzn/alexa-skills-kit-js#11 but I've separated it out per request.