### PR TITLE
include 'Hello World' Skill in samples listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The included samples represent how to use nodejs AWS Lambda functions as Alexa S
 The following samples are included (ordered by complexity, see the Using Alexa Skills Kit Samples
 link below for more details):
 
+- [HelloWorld](samples/helloWorld) : a simple skill that responds with "hello world!"
 - [SpaceGeek](samples/spaceGeek) : a simple skill that responds to the user with a space fact.
 - [ReindeerGames](samples/reindeerGames): a simple skill that plays trivia quiz questions
 - [MinecraftHelper](samples/minecraftHelper) : a simple skill that responds to the user's recipe queries with formulas.

--- a/samples/helloWorld/README.md
+++ b/samples/helloWorld/README.md
@@ -25,7 +25,7 @@ To run this example skill you need to do two things. The first is to deploy the 
 
 ### Alexa Skill Setup
 1. Go to the [Alexa Console](https://developer.amazon.com/edw/home.html) and click Add a New Skill.
-2. Set "HelloWorld" as the skill name and "greeter" as the invocation name, this is what is used to activate your skill. For example you would say: "Alexa, tell Greeter to say hello"
+2. Set "HelloWorld" as the skill name and "hello world" as the invocation name, this is what is used to activate your skill. For example you would say: "Alexa, tell Hello World to say hello"
 3. Select the Lambda ARN for the skill Endpoint and paste the ARN copied from above. Click Next.
 4. Copy the Intent Schema from the included IntentSchema.json.
 5. Copy the Sample Utterances from the included SampleUtterances.txt. Click Next.
@@ -36,5 +36,5 @@ To run this example skill you need to do two things. The first is to deploy the 
 9. Your skill is now saved and once you are finished testing you can continue to publish your skill.
 
 ## Examples
-    User: "Alexa, tell Greeter to say hello"
+    User: "Alexa, tell Hello World to say hello"
     Alexa: "Hello World!"

--- a/samples/helloWorld/src/index.js
+++ b/samples/helloWorld/src/index.js
@@ -14,7 +14,7 @@
  *
  * Examples:
  * One-shot model:
- *  User: "Alexa, tell Greeter to say hello"
+ *  User: "Alexa, tell Hello World to say hello"
  *  Alexa: "Hello World!"
  */
 
@@ -64,7 +64,7 @@ HelloWorld.prototype.eventHandlers.onSessionEnded = function (sessionEndedReques
 HelloWorld.prototype.intentHandlers = {
     // register custom intent handlers
     "HelloWorldIntent": function (intent, session, response) {
-        response.tellWithCard("Hello World!", "Greeter", "Hello World!");
+        response.tellWithCard("Hello World!", "Hello World", "Hello World!");
     },
     "AMAZON.HelpIntent": function (intent, session, response) {
         response.ask("You can say hello to me!", "You can say hello to me!");


### PR DESCRIPTION
- adds "Hello World" example to the skills listing in readme
- I also switched the invocation name to "Hello World" instead of "Greeter", since single-word invocation names are no longer allowed: https://developer.amazon.com/public/community/post/Tx1I0GCST7POI00/Tips-for-Choosing-an-Invocation-Name-for-Your-Alexa-Custom-Skill (see item 2 on the "New Invocation Name Requirements" list)