### PR TITLE
kludge fix for trying to launch with helpintent

### DIFF
--- a/samples/ChemistryFlashCards/src/index.js
+++ b/samples/ChemistryFlashCards/src/index.js
@@ -244,7 +244,11 @@ function onIntent(intentRequest, session, callback) {
     } else if ("AMAZON.RepeatIntent" === intentName) {
         handleRepeatRequest(intent, session, callback);
     } else if ("AMAZON.HelpIntent" === intentName) {
-        handleGetHelpRequest(intent, session, callback);
+        if (!session.attributes) {
+            getWelcomeResponse(callback);
+        } else { 
+            handleGetHelpRequest(intent, session, callback);
+        }
     } else if ("AMAZON.StopIntent" === intentName) {
         handleFinishSessionRequest(intent, session, callback);
     } else if ("AMAZON.CancelIntent" === intentName) {


### PR DESCRIPTION
The handleGetHelpRequest call passes a session object with no attributes if it is called on launch. This causes the function to fail and the Lambda won't fire as a result. This is a quick fix to get around that.