### PR TITLE
Fix Flash Card answer checker.

### DIFF
--- a/samples/ChemistryFlashCards/src/index.js
+++ b/samples/ChemistryFlashCards/src/index.js
@@ -396,7 +396,7 @@ function handleAnswerRequest(intent, session, callback) {
 
         var speechOutputAnalysis = "";
 
-        if (answerSlotValid && intent.slots.Answer.toUpperCase == correctAnswerText.toUpperCase) {
+        if (answerSlotValid && intent.slots.Answer.value.toUpperCase() === correctAnswerText.toUpperCase()) {
             currentScore++;
             speechOutputAnalysis = "correct. ";
         } else {


### PR DESCRIPTION
Invoke the toUpperCase function so we can compare results, rather than
comparing the [native code] function definition with itself.

Also gets the right value from the `intent.slots.Answer` object.