### PR TITLE
Incorrect type for answer slots if following tutorial,…

### DIFF
--- a/samples/reindeerGames/speechAssets/IntentSchema.json
+++ b/samples/reindeerGames/speechAssets/IntentSchema.json
@@ -5,7 +5,7 @@
       "slots": [
         {
           "name": "Answer",
-          "type": "LIST_OF_ANSWERS"
+          "type": "AMAZON.NUMBER"
         }
       ]
     },
@@ -14,7 +14,7 @@
       "slots": [
         {
           "name": "Answer",
-          "type": "LIST_OF_ANSWERS"
+          "type": "AMAZON.NUMBER"
         }
       ]
     },


### PR DESCRIPTION
 can never answer correctly

I was working through the tutorial "6 steps to create a trivia-based Alexa skill" and followed all steps. In testing I noticed that answers always created a request with the DontKnowIntent. After a bit of head scratching I realised that with the LIST_OF_ANSWERS cusotm slot type the game would never parse the numeric answers it was requesting.

The page with the incorrect steps is here
https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/content/trivia-skill-2